### PR TITLE
feat: add graph_widget data source

### DIFF
--- a/internal/provider/dashboard_body_builder.go
+++ b/internal/provider/dashboard_body_builder.go
@@ -39,7 +39,7 @@ type CWDashboardBodyWidgetPropertyMetric struct {
 	LiveData    bool                                            `json:"liveData,omitempty"`
 	Legend      *CWDashboardBodyWidgetPropertyMetricLegend      `json:"legend,omitempty"`
 	Metrics     [][]interface{}                                 `json:"metrics"`
-	Period      int                                             `json:"period,omitempty"`
+	Period      int32                                           `json:"period,omitempty"`
 	Region      string                                          `json:"region"`
 	Stat        string                                          `json:"stat,omitempty"`
 	Title       string                                          `json:"title,omitempty"`

--- a/internal/provider/graph_widget_data_source.go
+++ b/internal/provider/graph_widget_data_source.go
@@ -1,0 +1,207 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource = &graphWidgetDataSource{}
+)
+
+type graphWidgetDataSource struct {
+}
+
+func NewGraphWidgetDataSource() func() datasource.DataSource {
+	return func() datasource.DataSource {
+		return &graphWidgetDataSource{}
+	}
+}
+
+func (d *graphWidgetDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_graph_widget"
+}
+
+// Schema defines the schema for the data source.
+func (d *graphWidgetDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"end": schema.StringAttribute{
+				Description: "The end of the time range to use for each widget independently from those of the dashboard",
+				Optional:    true,
+			},
+			"height": schema.Int32Attribute{
+				Description: "Height of the widget",
+				Required:    true,
+			},
+			"left": schema.ListAttribute{
+				Description: "Metrics to display on left Y axis",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"legend_position": schema.StringAttribute{
+				Description: "Position of the legend",
+				Optional:    true,
+			},
+			"live_data": schema.BoolAttribute{
+				Description: "Whether the graph should show live data",
+				Optional:    true,
+			},
+			"period": schema.Int32Attribute{
+				Description: "The default period for all metrics in this widget",
+				Optional:    true,
+			},
+			"region": schema.StringAttribute{
+				Description: "The region the metrics of this graph should be taken from",
+				Optional:    true,
+			},
+			"right": schema.ListAttribute{
+				Description: "Metrics to display on right Y axis",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"stacked": schema.BoolAttribute{
+				Description: "Whether the graph should be shown as stacked lines",
+				Optional:    true,
+			},
+			"start": schema.StringAttribute{
+				Description: "The start of the time range to use for each widget independently from those of the dashboard",
+				Optional:    true,
+			},
+			"statistic": schema.StringAttribute{
+				Description: "The default statistic to be displayed for each metric",
+				Optional:    true,
+			},
+			"title": schema.StringAttribute{
+				Description: "Title for the graph",
+				Optional:    true,
+			},
+			"view": schema.StringAttribute{
+				Description: "Display this metric",
+				Optional:    true,
+			},
+			"width": schema.Int32Attribute{
+				Description: "Width of the widget, in a grid of 24 units wide",
+				Required:    true,
+			},
+			"json": schema.StringAttribute{
+				Description: "The settings of the widget",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+const (
+	typeGraphWidget = "graph"
+)
+
+type graphWidgetDataSourceModel struct {
+	End            types.String   `tfsdk:"end"`
+	Height         types.Int32    `tfsdk:"height"`
+	Left           []types.String `tfsdk:"left"` // JSON string containing array of metrics
+	LegendPosition types.String   `tfsdk:"legend_position"`
+	LiveData       types.Bool     `tfsdk:"live_data"`
+	Period         types.Int32    `tfsdk:"period"`
+	Region         types.String   `tfsdk:"region"`
+	Right          []types.String `tfsdk:"right"` // JSON string containing array of metrics
+	Stacked        types.Bool     `tfsdk:"stacked"`
+	Start          types.String   `tfsdk:"start"`
+	Statistic      types.String   `tfsdk:"statistic"`
+	Title          types.String   `tfsdk:"title"`
+	View           types.String   `tfsdk:"view"`
+	Width          types.Int32    `tfsdk:"width"`
+	Json           types.String   `tfsdk:"json"`
+}
+
+type graphWidgetDataSourceSettings struct {
+	Type           string                     `json:"type"`
+	End            string                     `json:"end,omitempty"`
+	Height         int32                      `json:"height"`
+	Left           []metricDataSourceSettings `json:"left,omitempty"`
+	LegendPosition string                     `json:"legend_position,omitempty"`
+	LiveData       bool                       `json:"live_data,omitempty"`
+	Period         int32                      `json:"period,omitempty"`
+	Region         string                     `json:"region,omitempty"`
+	Right          []metricDataSourceSettings `json:"right,omitempty"`
+	Stacked        bool                       `json:"stacked,omitempty"`
+	Start          string                     `json:"start,omitempty"`
+	Statistic      string                     `json:"statistic,omitempty"`
+	Title          string                     `json:"title,omitempty"`
+	View           string                     `json:"view,omitempty"`
+	Width          int32                      `json:"width"`
+}
+
+func (d *graphWidgetDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state graphWidgetDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Parse left metrics from JSON
+	leftMetrics := make([]metricDataSourceSettings, len(state.Left))
+	for i, metricJson := range state.Left {
+		var metric metricDataSourceSettings
+		if err := json.Unmarshal([]byte(metricJson.ValueString()), &metric); err != nil {
+			resp.Diagnostics.AddError("failed to unmarshal left metric", err.Error())
+			return
+		}
+		leftMetrics[i] = metric
+	}
+
+	// Parse right metrics from JSON
+	rightMetrics := make([]metricDataSourceSettings, len(state.Right))
+	for i, metricJson := range state.Right {
+		var metric metricDataSourceSettings
+		if err := json.Unmarshal([]byte(metricJson.ValueString()), &metric); err != nil {
+			resp.Diagnostics.AddError("failed to unmarshal right metric", err.Error())
+			return
+		}
+		rightMetrics[i] = metric
+	}
+
+	settings := graphWidgetDataSourceSettings{
+		Type:           typeGraphWidget,
+		End:            state.End.ValueString(),
+		Height:         state.Height.ValueInt32(),
+		Left:           leftMetrics,
+		LegendPosition: state.LegendPosition.ValueString(),
+		LiveData:       state.LiveData.ValueBool(),
+		Period:         state.Period.ValueInt32(),
+		Region:         state.Region.ValueString(),
+		Right:          rightMetrics,
+		Stacked:        state.Stacked.ValueBool(),
+		Start:          state.Start.ValueString(),
+		Statistic:      state.Statistic.ValueString(),
+		Title:          state.Title.ValueString(),
+		View:           state.View.ValueString(),
+		Width:          state.Width.ValueInt32(),
+	}
+
+	b, err := json.Marshal(settings)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to marshal widget settings", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "graph widget settings", map[string]interface{}{
+		"settings": string(b),
+	})
+
+	state.Json = types.StringValue(string(b))
+
+	stateDiags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(stateDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// TODO: add ToCWDashboardBodyWidget method

--- a/internal/provider/metric_data_source.go
+++ b/internal/provider/metric_data_source.go
@@ -104,10 +104,6 @@ type metricDataSourceSettings struct {
 	Unit          string            `json:"unit,omitempty"`
 }
 
-const (
-	typeMetric = "metric"
-)
-
 func (d *metricDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state metricDataSourceModel
 

--- a/internal/provider/metric_data_source.go
+++ b/internal/provider/metric_data_source.go
@@ -92,8 +92,6 @@ type metricDataSourceModel struct {
 }
 
 type metricDataSourceSettings struct {
-	Type string `json:"type"`
-
 	MetricName    string            `json:"metricName"`
 	Namespace     string            `json:"namespace"`
 	Account       string            `json:"account,omitempty"`
@@ -130,8 +128,6 @@ func (d *metricDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	settings := metricDataSourceSettings{
-		Type: typeMetric,
-
 		MetricName:    state.MetricName.ValueString(),
 		Namespace:     state.Namespace.ValueString(),
 		Account:       state.Account.ValueString(),

--- a/internal/provider/metric_data_source.go
+++ b/internal/provider/metric_data_source.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type metricDataSource struct {
@@ -65,6 +67,11 @@ func (d *metricDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Description: "Unit used to filter the metric stream",
 				Optional:    true,
 			},
+
+			"json": schema.StringAttribute{
+				Description: "The settings of the metric",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -80,6 +87,8 @@ type metricDataSourceModel struct {
 	Region        types.String `tfsdk:"region"`
 	Statistic     types.String `tfsdk:"statistic"`
 	Unit          types.String `tfsdk:"unit"`
+
+	Json types.String `tfsdk:"json"`
 }
 
 type metricDataSourceSettings struct {
@@ -110,8 +119,14 @@ func (d *metricDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	dimensionsMap := make(map[string]string)
-	for k, v := range state.DimensionsMap.Elements() {
-		dimensionsMap[k] = v.String()
+	for i, v := range state.DimensionsMap.Elements() {
+		switch typedV := v.(type) {
+		case types.String:
+			dimensionsMap[i] = typedV.ValueString()
+		default:
+			resp.Diagnostics.AddError("invalid type for dimensions map", "expected string")
+			return
+		}
 	}
 
 	settings := metricDataSourceSettings{
@@ -129,5 +144,16 @@ func (d *metricDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		Unit:          state.Unit.ValueString(),
 	}
 
-	resp.State.Set(ctx, settings)
+	b, err := json.Marshal(settings)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to marshal metric settings", err.Error())
+		return
+	}
+	tflog.Info(ctx, "metric settings", map[string]interface{}{
+		"settings": string(b),
+	})
+
+	state.Json = types.StringValue(string(b))
+
+	resp.State.Set(ctx, state)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,8 +41,12 @@ func (p *cwDashboardProvider) DataSources(_ context.Context) []func() datasource
 	return []func() datasource.DataSource{
 		NewDashboardDataSource(),
 
+		// Metric
+		NewMetricDataSource(),
+
 		// Widgets
 		NewTextWidgetDataSource(),
+		NewGraphWidgetDataSource(),
 	}
 }
 


### PR DESCRIPTION
## Input

```terraform
data "dashboard_metric" "ec2_cpu" {
  metric_name = "CPUUtilization"
  namespace   = "AWS/EC2"
  dimensions_map = {
    InstanceId = "i-1234567890abcdef0"
  }
  label     = "EC2 CPU Utilization"
  color     = "#1f77b4"
  statistic = "Average"
  period    = "300"
  region    = "ap-northeast-1"
  account   = "123456789012"
  unit      = "Percent"
}

data "dashboard_metric" "ec2_memory" {
  metric_name = "MemoryUtilization"
  namespace   = "AWS/EC2"
  dimensions_map = {
    InstanceId = "i-1234567890abcdef0"
  }
  label     = "EC2 Memory Utilization"
  color     = "#2ca02c"
  statistic = "Average"
  period    = "300"
  region    = "ap-northeast-1"
  unit      = "Percent"
}

data "dashboard_graph_widget" "graph_widget_1" {
  width  = 12
  height = 6

  start = "-P3D"
  end   = "2024-01-02T00:00:00.000Z"

  legend_position = "bottom"

  title     = "EC2 & RDS Metrics"
  view      = "timeSeries"
  live_data = true
  stacked   = false
  period    = 300
  region    = "ap-northeast-1"
  statistic = "Average"

  left = [
    data.dashboard_metric.ec2_cpu.json,
  ]

  right = [
    data.dashboard_metric.ec2_memory.json,
  ]
}

data "dashboard" "this" {
  start           = "-PT7D"
  end             = "2024-01-01T06:00:00.000Z"
  period_override = "auto"
  widgets = [
    data.dashboard_text_widget.text_widget_1.json,
    data.dashboard_text_widget.text_widget_2.json,
  ]
}

output "dashboard_graph_widget_1_json" {
  value = data.dashboard_graph_widget.graph_widget_1.json
}
```

## Output

```terraform
Changes to Outputs:
  + dashboard_graph_widget_1_json = jsonencode(
        {
          + end             = "2024-01-02T00:00:00.000Z"
          + height          = 6
          + left            = [
              + {
                  + account       = "123456789012"
                  + color         = "#1f77b4"
                  + dimensionsMap = {
                      + InstanceId = "i-1234567890abcdef0"
                    }
                  + label         = "EC2 CPU Utilization"
                  + metricName    = "CPUUtilization"
                  + namespace     = "AWS/EC2"
                  + period        = "300"
                  + region        = "ap-northeast-1"
                  + statistic     = "Average"
                  + unit          = "Percent"
                },
            ]
          + legend_position = "bottom"
          + live_data       = true
          + period          = 300
          + region          = "ap-northeast-1"
          + right           = [
              + {
                  + color         = "#2ca02c"
                  + dimensionsMap = {
                      + InstanceId = "i-1234567890abcdef0"
                    }
                  + label         = "EC2 Memory Utilization"
                  + metricName    = "MemoryUtilization"
                  + namespace     = "AWS/EC2"
                  + period        = "300"
                  + region        = "ap-northeast-1"
                  + statistic     = "Average"
                  + unit          = "Percent"
                },
            ]
          + start           = "-P3D"
          + statistic       = "Average"
          + title           = "EC2 & RDS Metrics"
          + type            = "graph"
          + view            = "timeSeries"
          + width           = 12
        }
    )
```